### PR TITLE
reposition annotations when view changes (instead of destroying)

### DIFF
--- a/src/iipmooviewer-2.0.js
+++ b/src/iipmooviewer-2.0.js
@@ -229,9 +229,6 @@ var IIPMooViewer = new Class({
     // Set our cursor
     this.canvas.setStyle( 'cursor', 'wait' );
 
-    // Delete our annotations
-    if( this.annotations ) this.destroyAnnotations();
-
     // Set our rotation origin - calculate differently if canvas is smaller than view port
     
     if( !Browser.buggy ){


### PR DESCRIPTION
Also, create `annotation_array` only once.

Note that this introduces a change: Annotation ids have `annotation` prepended to the created elements. This is so that when the id is a number (like it is in README.md), the id is still a valid id (HTML ids have to begin with a letter).
