### PR TITLE
increase z-index of tips so they appear in fullscreen. fixes #30

### DIFF
--- a/css/iip.css
+++ b/css/iip.css
@@ -151,6 +151,7 @@
   font-family: Verdana, sans-serif;
   font-size: 8pt;
   line-height: 1.2em;
+  z-index: 2;
   position: relative;
  -moz-border-radius: 0.5em;
   -webkit-border-radius: 0.5em;
@@ -159,11 +160,6 @@
   -webkit-box-shadow: 5px 5px 5px rgba(0,0,0,0.5);
   -o-box-shadow: 5px 5px 5px rgba(0,0,0,0.5);
   box-shadow: 5px 5px 5px rgba(0,0,0,0.5);
-
-  /*
-   * Needed so tips appear in fullscreen mode.
-   */
-  z-index: 2147483647;
 }
 .tip h1 {
   font-size: 120%;

--- a/src/iipmooviewer-2.0.js
+++ b/src/iipmooviewer-2.0.js
@@ -215,6 +215,20 @@ var IIPMooViewer = new Class({
     else if( Browser.opera ) this.CSSprefix = '-o-';
     else if( Browser.ie ) this.CSSprefix = 'ms-';  // Note that there should be no leading "-" !!
 
+    // Override the `show` method of the Tips class so that
+    // tips are children of the image-viewer container.
+    // This is needed so when the image-viewer container is
+    // "fullscreened", tips still show.
+    var _this = this;
+    Tips = new Class({
+      Extends: Tips,
+      show: function(element) {
+        if (!this.tip) document.id(this);
+        if (!this.tip.getParent()) this.tip.inject(document.id(_this.source));
+        this.fireEvent('show', [this.tip, element]);
+      }
+    });
+
 
     // Load us up when the DOM is fully loaded!
     window.addEvent( 'domready', this.load.bind(this) );


### PR DESCRIPTION
Not sure exactly why this is needed, and the only reference I could find to this issue was [in a Webkit test](https://github.com/adobe/webkit/blob/master/LayoutTests/fullscreen/full-screen-zIndex.html#L45).
