### PR TITLE
Added the missing toggleNavigationWindow() function

### DIFF
--- a/src/iipmooviewer-2.0.js
+++ b/src/iipmooviewer-2.0.js
@@ -1514,6 +1514,14 @@ var IIPMooViewer = new Class({
       var view = this.getView();
       this.navigation.update( view.x/this.wid, view.y/this.hei, view.w/this.wid, view.h/this.hei );
     }
+  },
+  
+  /* Toggle navigation window
+   */
+  toggleNavigationWindow: function() {
+    if( this.navigation ) {
+      this.navigation.toggleWindow();
+    }
   }
 
 });


### PR DESCRIPTION
The public toggleNavigationWindow() function is listed in the documentation but it wasn't there.
