### PR TITLE
New annotation bug : missing 'annotation-' prefix

### DIFF
--- a/src/annotations-edit.js
+++ b/src/annotations-edit.js
@@ -52,7 +52,7 @@ IIPMooViewer.implement({
 
     // Now draw the annotation
     var annotation = new Element('div', {
-      'id': id,
+      'id': 'annotation-' + id,
       'class': 'annotation edit',
       'styles': {
         left: Math.round( a.x * this.wid ),


### PR DESCRIPTION
Corrected a bug where a new annotation ID doesn't take the 'annotation-' prefix into account
